### PR TITLE
Fix return value

### DIFF
--- a/colourvalgrind/command_line.py
+++ b/colourvalgrind/command_line.py
@@ -24,7 +24,7 @@ def main():
         for line in iter(s.stdout.readline, b''):
             print(colour_valgrind(line.rstrip(b'\n').decode('utf-8')))
 
-        sys.exit(s.returncode)
+        sys.exit(s.wait())
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Exiting with `s.wait()` instead of `s.returnvalue` waits for subprocess completion and returns its result instead of always returning 0.